### PR TITLE
Correct calculation of Jacobian in prediction step for worksheet 4

### DIFF
--- a/s4_ekf_slam/octave/prediction_step.m
+++ b/s4_ekf_slam/octave/prediction_step.m
@@ -19,8 +19,8 @@ mu(3, 1) = normalize_angle(mu(3, 1));
 
 % Compute the 3x3 Jacobian Gx of the motion model
 Gx = eye(3, 3);
-Gx(1, 3) = -u.t * cos(mu(3) + u.r1);
-Gx(2, 3) = u.t * sin(mu(3) + u.r1);
+Gx(1, 3) = -u.t * sin(mu(3) + u.r1);
+Gx(2, 3) = u.t * cos(mu(3) + u.r1);
 
 % Construct the full Jacobian G
 G = [Gx, zeros(3, n-3); zeros(n-3, 3), eye(n-3)];


### PR DESCRIPTION
@varunbachalli highlighted in #5 that the Jacobian in the prediction step to worksheet 4 was being calculated incorrectly.

More about Jacobians can be found here:
 - https://math.libretexts.org/Bookshelves/Calculus/Supplemental_Modules_(Calculus)/Vector_Calculus/3%3A_Multiple_Integrals/3.8%3A_Jacobians